### PR TITLE
Increase performance of Raster thread

### DIFF
--- a/lib/views/home_page/book_cover/book_cover.dart
+++ b/lib/views/home_page/book_cover/book_cover.dart
@@ -86,7 +86,11 @@ class _BookCoverWidgetState extends State<BookCoverWidget> {
                 ),
 
                 /// Black overlay, fades out on mouseOver
-                AnimatedContainer(duration: Times.slow, color: Colors.black.withOpacity(overlayOpacity)),
+                if (overlayOpacity > 0)
+                  AnimatedContainer(
+                      duration: Times.slow,
+                      color: Colors.black.withOpacity(overlayOpacity),
+                  ),
 
                 /// When in large mode, show some gradients, should sit under the Text elements
                 if (widget.largeMode) ...[


### PR DESCRIPTION
All this does is avoid adding an animated container when the opacity is 0 (which it is most of the time).

The new line avoids an unintuitive behavior of the Flutter Framework, in which a fully transparent overlay cannot be ignored by the rasterizer. More info here: https://github.com/flutter/flutter/pull/72526#issuecomment-749185938.

I wasn’t able to test this, but I’m pretty sure this will have the effect of skipping the overlay animation when the opacity goes from 0 to non-zero (because AnimatedContainer only animates itself if it’s there for both the before and after — and I’m removing the before). If this is too jarring, we can think about other creative ways to still get that performance boost.