### PR TITLE
fixed conflicting imports

### DIFF
--- a/lib/views/auth_page/device_screens.dart
+++ b/lib/views/auth_page/device_screens.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_folio/_widgets/animated/animated_scale.dart';
+import 'package:flutter_folio/_widgets/animated/animated_scale.dart' as amscale;
 import 'package:flutter_folio/_widgets/gradient_container.dart';
 import 'package:flutter_folio/core_packages.dart';
 
@@ -85,7 +85,7 @@ class _LandingPageImage extends StatelessWidget {
           left: offset.dx,
           top: offset.dy,
           height: height,
-          child: AnimatedScale(
+          child: amscale.AnimatedScale(
             begin: 1,
             end: scale,
             duration: Times.fast,

--- a/lib/views/home_page/book_cover/book_cover.dart
+++ b/lib/views/home_page/book_cover/book_cover.dart
@@ -2,7 +2,7 @@ import 'package:animate_do/animate_do.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter_folio/_utils/input_utils.dart';
-import 'package:flutter_folio/_widgets/animated/animated_scale.dart';
+import 'package:flutter_folio/_widgets/animated/animated_scale.dart' as amscale;
 import 'package:flutter_folio/_widgets/gradient_container.dart';
 import 'package:flutter_folio/_widgets/rounded_card.dart';
 import 'package:flutter_folio/core_packages.dart';
@@ -78,7 +78,7 @@ class _BookCoverWidgetState extends State<BookCoverWidget> {
                 /// /////////////////////////////
                 /// Background Image
                 // Animated scale for when we mouse-over
-                AnimatedScale(
+                amscale.AnimatedScale(
                   duration: Times.slow,
                   begin: 1,
                   end: isClickable ? 1.1 : 1,

--- a/lib/views/home_page/covers_sortable_list.dart
+++ b/lib/views/home_page/covers_sortable_list.dart
@@ -6,7 +6,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter_folio/_utils/device_info.dart';
 import 'package:flutter_folio/_widgets/alignments.dart';
-import 'package:flutter_folio/_widgets/animated/animated_rotation.dart';
+import 'package:flutter_folio/_widgets/animated/animated_rotation.dart' as amrotation;
 import 'package:flutter_folio/_widgets/gradient_container.dart';
 import 'package:flutter_folio/commands/books/set_current_book_command.dart';
 import 'package:flutter_folio/core_packages.dart';
@@ -184,7 +184,7 @@ class SortableListHeader extends StatelessWidget {
             AnimatedOpacity(
               opacity: sortDir == 0 ? 0 : 1,
               duration: Times.fast,
-              child: AnimatedRotation(
+              child: amrotation.AnimatedRotation(
                 duration: Times.fast,
                 end: sortDir == 1 ? 180 : 0,
                 child: Icon(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -14,7 +14,7 @@ packages:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.1"
+    version: "1.7.2"
   anchored_popups:
     dependency: "direct main"
     description:
@@ -56,7 +56,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.6.1"
+    version: "2.8.1"
   auto_size_text:
     dependency: "direct main"
     description:
@@ -198,7 +198,7 @@ packages:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -359,7 +359,7 @@ packages:
       name: file
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.1.0"
+    version: "6.1.2"
   file_selector:
     dependency: "direct main"
     description:
@@ -741,7 +741,7 @@ packages:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.7.0"
   mime:
     dependency: transitive
     description:
@@ -888,7 +888,7 @@ packages:
       name: process
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.2.1"
+    version: "4.2.3"
   protobuf:
     dependency: transitive
     description:
@@ -1131,21 +1131,21 @@ packages:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.16.8"
+    version: "1.17.10"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.0"
+    version: "0.4.2"
   test_core:
     dependency: transitive
     description:
       name: test_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.19"
+    version: "0.4.0"
   timeago:
     dependency: "direct main"
     description:
@@ -1243,7 +1243,7 @@ packages:
       name: vm_service
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.2.0"
+    version: "7.1.1"
   watcher:
     dependency: transitive
     description:

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -2,6 +2,8 @@
 //  Generated file. Do not edit.
 //
 
+// clang-format off
+
 #include "generated_plugin_registrant.h"
 
 #include <bitsdojo_window_windows/bitsdojo_window_plugin.h>

--- a/windows/flutter/generated_plugin_registrant.h
+++ b/windows/flutter/generated_plugin_registrant.h
@@ -2,6 +2,8 @@
 //  Generated file. Do not edit.
 //
 
+// clang-format off
+
 #ifndef GENERATED_PLUGIN_REGISTRANT_
 #define GENERATED_PLUGIN_REGISTRANT_
 


### PR DESCRIPTION
When building against Flutter 2.5.2, there are lots of errors related to conflicting imports for `AnimatedRotation` and `AnimatedScale`.  This fixes those to reference the versions inside the project.